### PR TITLE
modified project configuration to allow library to be used in tests

### DIFF
--- a/Selenium/Selenium.xcodeproj/project.pbxproj
+++ b/Selenium/Selenium.xcodeproj/project.pbxproj
@@ -494,7 +494,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Selenium/Selenium-Prefix.pch";
 				INFOPLIST_FILE = "Selenium/Selenium-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
+				INSTALL_PATH = "@loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -512,7 +512,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Selenium/Selenium-Prefix.pch";
 				INFOPLIST_FILE = "Selenium/Selenium-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
+				INSTALL_PATH = "@loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;


### PR DESCRIPTION
previously, the installation directory was based on @executable_path, which
is fine if we're linking to an executable like appium, but doesn't work
when linking with tests. changed to @loader_path
