### PR TITLE
Add libSelenium static library target

### DIFF
--- a/Selenium/Selenium.xcodeproj/project.pbxproj
+++ b/Selenium/Selenium.xcodeproj/project.pbxproj
@@ -38,6 +38,31 @@
 		36F3D75716F7E39100A5DD70 /* SEWebElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 36F3D75516F7E39100A5DD70 /* SEWebElement.m */; };
 		6B93026317011246003F4CFF /* SELocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B93026217011246003F4CFF /* SELocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B93026517011418003F4CFF /* SELocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B93026417011418003F4CFF /* SELocation.m */; };
+		DB922EB318BC803C005C2F1E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36BB380416F268C2003A46FD /* Cocoa.framework */; };
+		DB922ED318BC8075005C2F1E /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 36A03F9016FA0F2A00F61F08 /* NSData+Base64.m */; };
+		DB922ED418BC8075005C2F1E /* SEBy.m in Sources */ = {isa = PBXBuildFile; fileRef = 36F3D75116F7DFE700A5DD70 /* SEBy.m */; };
+		DB922ED518BC8075005C2F1E /* SESession.m in Sources */ = {isa = PBXBuildFile; fileRef = 36BB383C16F26945003A46FD /* SESession.m */; };
+		DB922ED618BC8075005C2F1E /* SELocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B93026417011418003F4CFF /* SELocation.m */; };
+		DB922ED718BC8075005C2F1E /* SEStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 36BB384016F26951003A46FD /* SEStatus.m */; };
+		DB922ED818BC8075005C2F1E /* SECapabilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 36BB383816F26926003A46FD /* SECapabilities.m */; };
+		DB922ED918BC8075005C2F1E /* SEEnums.m in Sources */ = {isa = PBXBuildFile; fileRef = 36C3AFA116F9379C000E73C6 /* SEEnums.m */; };
+		DB922EDA18BC8075005C2F1E /* SEError.m in Sources */ = {isa = PBXBuildFile; fileRef = 360609C216F5657600BADCDE /* SEError.m */; };
+		DB922EDB18BC8075005C2F1E /* SEWebElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 36F3D75516F7E39100A5DD70 /* SEWebElement.m */; };
+		DB922EDC18BC8075005C2F1E /* SEUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 360486EE16F7C15100D968D8 /* SEUtility.m */; };
+		DB922EDD18BC8075005C2F1E /* SEJsonWireClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 36A5B25B16F8EFAE00AB30AF /* SEJsonWireClient.m */; };
+		DB922EDE18BC8075005C2F1E /* SERemoteWebDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 36BB383416F26907003A46FD /* SERemoteWebDriver.m */; };
+		DB922EDF18BC807D005C2F1E /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 36A03F8F16FA0F2A00F61F08 /* NSData+Base64.h */; };
+		DB922EE018BC807D005C2F1E /* SEBy.h in Headers */ = {isa = PBXBuildFile; fileRef = 36F3D75016F7DFE700A5DD70 /* SEBy.h */; };
+		DB922EE118BC807D005C2F1E /* SESession.h in Headers */ = {isa = PBXBuildFile; fileRef = 36BB383B16F26945003A46FD /* SESession.h */; };
+		DB922EE218BC807D005C2F1E /* SELocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B93026217011246003F4CFF /* SELocation.h */; };
+		DB922EE318BC807D005C2F1E /* SEStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 36BB383F16F26951003A46FD /* SEStatus.h */; };
+		DB922EE418BC807D005C2F1E /* SECapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 36BB383716F26926003A46FD /* SECapabilities.h */; };
+		DB922EE518BC807D005C2F1E /* SEEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = 36C3AFA016F9379C000E73C6 /* SEEnums.h */; };
+		DB922EE618BC807D005C2F1E /* SEError.h in Headers */ = {isa = PBXBuildFile; fileRef = 360609C116F5657600BADCDE /* SEError.h */; };
+		DB922EE718BC807D005C2F1E /* SEWebElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 36F3D75416F7E39100A5DD70 /* SEWebElement.h */; };
+		DB922EE818BC807D005C2F1E /* SEUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 360486ED16F7C15100D968D8 /* SEUtility.h */; };
+		DB922EE918BC807D005C2F1E /* SEJsonWireClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 36A5B25A16F8EFAE00AB30AF /* SEJsonWireClient.h */; };
+		DB922EEA18BC807D005C2F1E /* SERemoteWebDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 36BB383316F26907003A46FD /* SERemoteWebDriver.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +114,8 @@
 		36F3D75516F7E39100A5DD70 /* SEWebElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEWebElement.m; sourceTree = "<group>"; };
 		6B93026217011246003F4CFF /* SELocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SELocation.h; sourceTree = "<group>"; };
 		6B93026417011418003F4CFF /* SELocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SELocation.m; sourceTree = "<group>"; };
+		DB922EB218BC803C005C2F1E /* liblibSelenium.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblibSelenium.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DB922EBF18BC803C005C2F1E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +134,14 @@
 				36BB381B16F268C2003A46FD /* SenTestingKit.framework in Frameworks */,
 				36BB381C16F268C2003A46FD /* Cocoa.framework in Frameworks */,
 				36BB381F16F268C2003A46FD /* Selenium.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB922EAF18BC803C005C2F1E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB922EB318BC803C005C2F1E /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -148,6 +183,7 @@
 			children = (
 				36BB380116F268C2003A46FD /* Selenium.framework */,
 				36BB381916F268C2003A46FD /* SeleniumTests.octest */,
+				DB922EB218BC803C005C2F1E /* liblibSelenium.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -157,6 +193,7 @@
 			children = (
 				36BB380416F268C2003A46FD /* Cocoa.framework */,
 				36BB381A16F268C2003A46FD /* SenTestingKit.framework */,
+				DB922EBF18BC803C005C2F1E /* XCTest.framework */,
 				36BB380616F268C2003A46FD /* Other Frameworks */,
 			);
 			name = Frameworks;
@@ -267,6 +304,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DB922EB018BC803C005C2F1E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB922EDF18BC807D005C2F1E /* NSData+Base64.h in Headers */,
+				DB922EE018BC807D005C2F1E /* SEBy.h in Headers */,
+				DB922EE118BC807D005C2F1E /* SESession.h in Headers */,
+				DB922EE218BC807D005C2F1E /* SELocation.h in Headers */,
+				DB922EE318BC807D005C2F1E /* SEStatus.h in Headers */,
+				DB922EE418BC807D005C2F1E /* SECapabilities.h in Headers */,
+				DB922EE518BC807D005C2F1E /* SEEnums.h in Headers */,
+				DB922EE618BC807D005C2F1E /* SEError.h in Headers */,
+				DB922EE718BC807D005C2F1E /* SEWebElement.h in Headers */,
+				DB922EE818BC807D005C2F1E /* SEUtility.h in Headers */,
+				DB922EE918BC807D005C2F1E /* SEJsonWireClient.h in Headers */,
+				DB922EEA18BC807D005C2F1E /* SERemoteWebDriver.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -307,6 +363,23 @@
 			productReference = 36BB381916F268C2003A46FD /* SeleniumTests.octest */;
 			productType = "com.apple.product-type.bundle";
 		};
+		DB922EB118BC803C005C2F1E /* libSelenium */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DB922ED118BC803C005C2F1E /* Build configuration list for PBXNativeTarget "libSelenium" */;
+			buildPhases = (
+				DB922EAE18BC803C005C2F1E /* Sources */,
+				DB922EAF18BC803C005C2F1E /* Frameworks */,
+				DB922EB018BC803C005C2F1E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = libSelenium;
+			productName = libSelenium;
+			productReference = DB922EB218BC803C005C2F1E /* liblibSelenium.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -330,6 +403,7 @@
 			targets = (
 				36BB380016F268C2003A46FD /* Selenium */,
 				36BB381816F268C2003A46FD /* SeleniumTests */,
+				DB922EB118BC803C005C2F1E /* libSelenium */,
 			);
 		};
 /* End PBXProject section */
@@ -394,6 +468,25 @@
 			buildActionMask = 2147483647;
 			files = (
 				36BB382816F268C2003A46FD /* SeleniumTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB922EAE18BC803C005C2F1E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB922ED318BC8075005C2F1E /* NSData+Base64.m in Sources */,
+				DB922ED418BC8075005C2F1E /* SEBy.m in Sources */,
+				DB922ED518BC8075005C2F1E /* SESession.m in Sources */,
+				DB922ED618BC8075005C2F1E /* SELocation.m in Sources */,
+				DB922ED718BC8075005C2F1E /* SEStatus.m in Sources */,
+				DB922ED818BC8075005C2F1E /* SECapabilities.m in Sources */,
+				DB922ED918BC8075005C2F1E /* SEEnums.m in Sources */,
+				DB922EDA18BC8075005C2F1E /* SEError.m in Sources */,
+				DB922EDB18BC8075005C2F1E /* SEWebElement.m in Sources */,
+				DB922EDC18BC8075005C2F1E /* SEUtility.m in Sources */,
+				DB922EDD18BC8075005C2F1E /* SEJsonWireClient.m in Sources */,
+				DB922EDE18BC8075005C2F1E /* SERemoteWebDriver.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,6 +639,24 @@
 			};
 			name = Release;
 		};
+		DB922ECD18BC803C005C2F1E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Selenium/Selenium-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		DB922ECE18BC803C005C2F1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Selenium/Selenium-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -575,6 +686,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		DB922ED118BC803C005C2F1E /* Build configuration list for PBXNativeTarget "libSelenium" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DB922ECD18BC803C005C2F1E /* Debug */,
+				DB922ECE18BC803C005C2F1E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
Attempting to link against Selenium.framework from within an XCTest bundle (and not from within a target app) creates runpath errors on test execution, due to dyld searching for Selenium.framework at @executable_path/../Frameworks/Selenium.framework, where @executable_path is the target app and not the XCTest bundle.

To work around this, I made a new target for the existing code to build a static library called libSelenium, which does link and run successfully from within an XCTest bundle.
