### PR TITLE
POST /session/:sessionid/context expects 'name', not 'context' for context name.

### DIFF
--- a/Selenium/Selenium/SEJsonWireClient.m
+++ b/Selenium/Selenium/SEJsonWireClient.m
@@ -123,7 +123,7 @@
 -(void) postContext:(NSString*)context session:(NSString*)sessionId error:(NSError**)error
 {
     NSString *urlString = [NSString stringWithFormat:@"%@/session/%@/context", self.httpCommandExecutor, sessionId];
-    NSDictionary *postDictionary = [[NSDictionary alloc] initWithObjectsAndKeys:context, @"context", nil];
+    NSDictionary *postDictionary = [[NSDictionary alloc] initWithObjectsAndKeys:context, @"name", nil];
     [SEUtility performPostRequestToUrl:urlString postParams:postDictionary error:error];
 }
 


### PR DESCRIPTION
When using Appium inspector, I cannot change the context. Here is the response from the Appium server:

```
info: --> POST /wd/hub/session/12216009-328d-4477-903c-ec3be78af798/context {"context":"WEBVIEW_1"}
info: [debug] Missing params for request: ["name"]
info: <-- POST /wd/hub/session/12216009-328d-4477-903c-ec3be78af798/context 400 2.637 ms - 28
```

It appears that the [Appium server expects](https://github.com/appium/appium/blob/master/lib/server/controller.js#L1019-L1025) "name"  for the context handle name instead of "context" in the request. [JSON Wire Protocol does not define a command for "context"](https://code.google.com/p/selenium/wiki/JsonWireProtocol). I checked with the Appium Java client (which does successfully change contexts) and it [appears to use "name" as well](https://github.com/appium/java-client/blob/master/src/main/java/io/appium/java_client/AppiumDriver.java#L524-L531).

Tested by building the Selenium.framework, dropping it into the Appium.app, and switching the context via Inspector, which now succeeds: 

```
info: --> POST /wd/hub/session/a61db2f2-1cb7-4d0a-aba8-f056f9dc3499/context {"name":"NATIVE_APP"}
info: [debug] Attempting to set context to 'NATIVE_APP'
info: [debug] Responding to client with success: {"status":0,"value":"","sessionId":"a61db2f2-1cb7-4d0a-aba8-f056f9dc3499"}
info: <-- POST /wd/hub/session/a61db2f2-1cb7-4d0a-aba8-f056f9dc3499/context 200 2.789 ms - 74 {"status":0,"value":"","sessionId":"a61db2f2-1cb7-4d0a-aba8-f056f9dc3499"}
```
